### PR TITLE
WIP: Add support httpOptions

### DIFF
--- a/packages/gatsby-source-prismic/src/buildDependencies.ts
+++ b/packages/gatsby-source-prismic/src/buildDependencies.ts
@@ -26,10 +26,17 @@ export const buildDependencies = (
   const prismicEndpoint =
     pluginOptions.apiEndpoint ??
     prismic.getEndpoint(pluginOptions.repositoryName)
+
+  const httpOptions = {
+    ...(pluginOptions?.httpOptions?.agent?.http && {
+      agent: pluginOptions?.httpOptions?.agent?.http
+    })
+  };
+
   const prismicClient = prismic.createClient(prismicEndpoint, {
     fetch,
     accessToken: pluginOptions.accessToken,
-    htttpOptions: pluginOptions?.htttpOptions?.agent?.http,
+    httpOptions,
     defaultParams: {
       lang: pluginOptions.lang,
       fetchLinks: pluginOptions.fetchLinks,

--- a/packages/gatsby-source-prismic/src/buildDependencies.ts
+++ b/packages/gatsby-source-prismic/src/buildDependencies.ts
@@ -29,6 +29,7 @@ export const buildDependencies = (
   const prismicClient = prismic.createClient(prismicEndpoint, {
     fetch,
     accessToken: pluginOptions.accessToken,
+    htttpOptions: pluginOptions?.htttpOptions?.agent?.http,
     defaultParams: {
       lang: pluginOptions.lang,
       fetchLinks: pluginOptions.fetchLinks,

--- a/packages/gatsby-source-prismic/src/builders/buildImageBaseFieldConfigMap.ts
+++ b/packages/gatsby-source-prismic/src/builders/buildImageBaseFieldConfigMap.ts
@@ -173,6 +173,7 @@ export const buildImageBaseFieldConfigMap: RTE.ReaderTaskEither<
               url: source.url,
               store: scope.store,
               cache: scope.cache,
+              httpOptions: scope.pluginOptions.httpOptions,
               createNode: scope.createNode,
               createNodeId: scope.createNodeId,
               reporter: scope.reporter,

--- a/packages/gatsby-source-prismic/src/builders/buildLinkType.ts
+++ b/packages/gatsby-source-prismic/src/builders/buildLinkType.ts
@@ -61,6 +61,7 @@ export const buildLinkType: RTE.ReaderTaskEither<
                   url: source.url,
                   store: deps.store,
                   cache: deps.cache,
+                  httpOptions: deps.pluginOptions?.httpOptions,
                   createNode: deps.createNode,
                   createNodeId: deps.createNodeId,
                   reporter: deps.reporter,

--- a/packages/gatsby-source-prismic/src/lib/createRemoteFileNode.ts
+++ b/packages/gatsby-source-prismic/src/lib/createRemoteFileNode.ts
@@ -27,6 +27,7 @@ export const createRemoteFileNode = (
               cache: deps.cache,
               createNode: deps.createNode,
               createNodeId: deps.createNodeId,
+              httpOptions: deps.pluginOptions?.httpOptions,
               reporter: deps.reporter,
             }),
           (e) => e as Error,

--- a/packages/gatsby-source-prismic/src/plugin-options-schema.ts
+++ b/packages/gatsby-source-prismic/src/plugin-options-schema.ts
@@ -203,8 +203,8 @@ export const pluginOptionsSchema: NonNullable<
     schemas: Joi.object(),
     httpOptions: Joi.object({
       agent: Joi.object({
-        http: Joi.object(),
-        https: Joi.object()
+        http: Joi.any(),
+        https: Joi.any()
       })
     }),
     imageImgixParams: Joi.object().default(DEFAULT_IMGIX_PARAMS),

--- a/packages/gatsby-source-prismic/src/plugin-options-schema.ts
+++ b/packages/gatsby-source-prismic/src/plugin-options-schema.ts
@@ -200,6 +200,12 @@ export const pluginOptionsSchema: NonNullable<
     linkResolver: Joi.function(),
     htmlSerializer: Joi.function(),
     schemas: Joi.object(),
+    httpOptions: Joi.object({
+      agent: Joi.object({
+        http: Joi.object(),
+        https: Joi.object()
+      })
+    }),
     imageImgixParams: Joi.object().default(DEFAULT_IMGIX_PARAMS),
     imagePlaceholderImgixParams: Joi.object().default(
       DEFAULT_PLACEHOLDER_IMGIX_PARAMS,

--- a/packages/gatsby-source-prismic/src/plugin-options-schema.ts
+++ b/packages/gatsby-source-prismic/src/plugin-options-schema.ts
@@ -121,6 +121,7 @@ const externalValidationProgram = (
           {
             fetch,
             accessToken: deps.pluginOptions.accessToken,
+            httpOptions: deps.pluginOptions.httpOptions,
           },
         ),
       ),

--- a/packages/gatsby-source-prismic/src/types.ts
+++ b/packages/gatsby-source-prismic/src/types.ts
@@ -7,6 +7,7 @@ import * as prismicT from '@prismicio/types'
 import * as gqlc from 'graphql-compose'
 import * as RTE from 'fp-ts/ReaderTaskEither'
 import { NodeHelpers } from 'gatsby-node-helpers'
+import { Agent } from 'http'
 
 export type Mutable<T> = {
   -readonly [P in keyof T]: T[P]
@@ -26,6 +27,13 @@ export type IterableElement<TargetIterable> = TargetIterable extends Iterable<
 export type JoiValidationError = InstanceType<
   gatsby.PluginOptionsSchemaArgs['Joi']['ValidationError']
 >
+
+export interface HttpOptions {
+  agent: {
+    http: Agent
+    https: Agent
+   }
+}
 
 export interface TypePath {
   path: string[]
@@ -58,6 +66,7 @@ export interface Dependencies {
   nodeHelpers: NodeHelpers
   pluginOptions: PluginOptions
   webhookBody?: unknown
+  httpOptions?: HttpOptions
   createRemoteFileNode: typeof gatsbyFs.createRemoteFileNode
 }
 

--- a/packages/gatsby-source-prismic/src/types.ts
+++ b/packages/gatsby-source-prismic/src/types.ts
@@ -88,6 +88,7 @@ export interface PluginOptions extends gatsby.PluginOptions {
   typePrefix?: string
   webhookSecret?: string
   plugins: []
+  httpOptions?: HttpOptions
   createRemoteFileNode: typeof gatsbyFs.createRemoteFileNode
   transformFieldName: (fieldName: string) => string
 }


### PR DESCRIPTION
:wave: 

Cf https://github.com/prismicio/prismic-javascript/pull/187 to add support for http Agent inside requests.

Types are broken because they come from https://github.com/prismicio/prismic-custom-types-client/blob/main/src/client.ts

- [ ] tests

## Package

<!--- Which packages are affected? Put an `x` in all the boxes that apply: -->

- [x] gatsby-source-prismic
- [ ] gatsby-plugin-prismic-previews

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [ ] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [ ] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
