### PR TITLE
Use useIsomorphicLayoutEffect instead of useLayoutEffect

### DIFF
--- a/packages/gatsby-plugin-prismic-previews/src/context.tsx
+++ b/packages/gatsby-plugin-prismic-previews/src/context.tsx
@@ -319,6 +319,11 @@ export type PrismicProviderProps = {
   children?: React.ReactNode
 }
 
+// React currently throws a warning when using useLayoutEffect on the server.
+// To get around it, we can conditionally useEffect on the server (no-op) and
+// useLayoutEffect in the browser.
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect;
+
 export const PrismicPreviewProvider = ({
   repositoryConfigs,
   children,
@@ -326,7 +331,7 @@ export const PrismicPreviewProvider = ({
   const initialState = createInitialState(repositoryConfigs)()
   const reducerTuple = React.useReducer(contextReducer, initialState)
 
-  React.useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     window[WINDOW_PROVIDER_PRESENCE_KEY] = true
   }, [])
 


### PR DESCRIPTION
## Package

- [ ] gatsby-source-prismic
- [x ] gatsby-plugin-prismic-previews

## Types of changes

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

React currently throws a warning when using useLayoutEffect on the server. To get around it, we can conditionally useEffect on the server (no-op) and useLayoutEffect in the browser.

## Checklist:

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.
