### PR TITLE
feat: add `pageSize` option

### DIFF
--- a/packages/gatsby-plugin-prismic-previews/package.json
+++ b/packages/gatsby-plugin-prismic-previews/package.json
@@ -37,7 +37,7 @@
   ],
   "dependencies": {
     "@imgix/gatsby": "^1.6.13",
-    "@prismicio/client": "6.0.0-beta.0",
+    "@prismicio/client": "6.0.0-alpha.8",
     "@prismicio/helpers": "^2.0.0-beta.0",
     "@prismicio/types": "^0.1.13",
     "@reach/dialog": "^0.16.0",

--- a/packages/gatsby-plugin-prismic-previews/src/plugin-options-schema.ts
+++ b/packages/gatsby-plugin-prismic-previews/src/plugin-options-schema.ts
@@ -33,6 +33,9 @@ export const pluginOptionsSchema: NonNullable<
     graphQuery: Joi.string(),
     fetchLinks: Joi.array().items(Joi.string().required()),
     lang: Joi.string().default(DEFAULT_LANG),
+    // TODO: Remove the hardcoded default once this PR to @prismicio/client is merged:
+    // https://github.com/prismicio/prismic-client/pull/195
+    pageSize: Joi.number().default(100),
     imageImgixParams: Joi.object().default(DEFAULT_IMGIX_PARAMS),
     imagePlaceholderImgixParams: Joi.object().default(
       DEFAULT_PLACEHOLDER_IMGIX_PARAMS,

--- a/packages/gatsby-plugin-prismic-previews/src/types.ts
+++ b/packages/gatsby-plugin-prismic-previews/src/types.ts
@@ -23,6 +23,7 @@ export interface PluginOptions extends gatsby.PluginOptions {
   graphQuery?: string
   fetchLinks?: string[]
   lang: string
+  pageSize: number
   imageImgixParams: imgixGatsby.ImgixUrlParams
   imagePlaceholderImgixParams: imgixGatsby.ImgixUrlParams
   typePrefix?: string

--- a/packages/gatsby-plugin-prismic-previews/src/usePrismicPreviewBootstrap.ts
+++ b/packages/gatsby-plugin-prismic-previews/src/usePrismicPreviewBootstrap.ts
@@ -186,13 +186,16 @@ export const usePrismicPreviewBootstrap = (
         lang: repositoryPluginOptions.lang,
         fetchLinks: repositoryPluginOptions.fetchLinks,
         graphQuery: repositoryPluginOptions.graphQuery,
+        pageSize: repositoryPluginOptions.pageSize,
       },
     })
     client.enableAutoPreviews()
 
     let allDocuments: prismicT.PrismicDocument[]
     try {
-      allDocuments = await client.getAll()
+      allDocuments = await client.getAll({
+        pageSize: repositoryPluginOptions.pageSize,
+      })
     } catch (error) {
       if (
         error instanceof prismic.ForbiddenError &&

--- a/packages/gatsby-plugin-prismic-previews/src/usePrismicPreviewResolver.ts
+++ b/packages/gatsby-plugin-prismic-previews/src/usePrismicPreviewResolver.ts
@@ -118,6 +118,7 @@ export const usePrismicPreviewResolver = (
         lang: repositoryPluginOptions.lang,
         fetchLinks: repositoryPluginOptions.fetchLinks,
         graphQuery: repositoryPluginOptions.graphQuery,
+        pageSize: repositoryPluginOptions.pageSize,
       },
     })
     client.enableAutoPreviews()

--- a/packages/gatsby-plugin-prismic-previews/test/__testutils__/createPluginOptions.ts
+++ b/packages/gatsby-plugin-prismic-previews/test/__testutils__/createPluginOptions.ts
@@ -14,6 +14,7 @@ export const createPluginOptions = (t: ava.ExecutionContext): PluginOptions => {
     apiEndpoint: prismic.getEndpoint(repositoryName),
     typePrefix: 'prefix',
     lang: '*',
+    pageSize: 100,
     toolbar: 'new',
     imageImgixParams: { q: 100 },
     imagePlaceholderImgixParams: { w: 10 },

--- a/packages/gatsby-plugin-prismic-previews/test/usePrismicPreviewBootstrap-field-proxies.test.ts
+++ b/packages/gatsby-plugin-prismic-previews/test/usePrismicPreviewBootstrap-field-proxies.test.ts
@@ -799,7 +799,7 @@ test.serial('group', async (t) => {
   )
 })
 
-test.serial('slices', async (t) => {
+test.serial.only('slices', async (t) => {
   const gatsbyContext = createGatsbyContext()
   const pluginOptions = createPluginOptions(t)
   const config = createRepositoryConfigs(pluginOptions)

--- a/packages/gatsby-source-prismic/package.json
+++ b/packages/gatsby-source-prismic/package.json
@@ -34,7 +34,7 @@
   ],
   "dependencies": {
     "@imgix/gatsby": "^1.6.13",
-    "@prismicio/client": "6.0.0-beta.0",
+    "@prismicio/client": "6.0.0-alpha.8",
     "@prismicio/custom-types-client": "^0.0.6",
     "@prismicio/helpers": "^2.0.0-beta.0",
     "@prismicio/types": "^0.1.13",

--- a/packages/gatsby-source-prismic/src/buildDependencies.ts
+++ b/packages/gatsby-source-prismic/src/buildDependencies.ts
@@ -32,6 +32,7 @@ export const buildDependencies = (
       lang: pluginOptions.lang,
       fetchLinks: pluginOptions.fetchLinks,
       graphQuery: pluginOptions.graphQuery,
+      pageSize: pluginOptions.pageSize,
     },
   })
 

--- a/packages/gatsby-source-prismic/src/lib/queryAllDocuments.ts
+++ b/packages/gatsby-source-prismic/src/lib/queryAllDocuments.ts
@@ -27,5 +27,11 @@ export const queryAllDocuments: RTE.ReaderTaskEither<
   prismicT.PrismicDocument[]
 > = pipe(
   RTE.ask<Dependencies>(),
-  RTE.chain((env) => RTE.fromTask(() => env.prismicClient.getAll())),
+  RTE.chain((env) =>
+    RTE.fromTask(() =>
+      env.prismicClient.getAll({
+        pageSize: env.pluginOptions.pageSize,
+      }),
+    ),
+  ),
 )

--- a/packages/gatsby-source-prismic/src/lib/queryDocumentsByIds.ts
+++ b/packages/gatsby-source-prismic/src/lib/queryDocumentsByIds.ts
@@ -24,5 +24,11 @@ export const queryDocumentsByIds = (
 ): RTE.ReaderTaskEither<Dependencies, Error, prismicT.PrismicDocument[]> =>
   pipe(
     RTE.ask<Dependencies>(),
-    RTE.chain((env) => RTE.fromTask(() => env.prismicClient.getAllByIDs(ids))),
+    RTE.chain((env) =>
+      RTE.fromTask(() =>
+        env.prismicClient.getAllByIDs(ids, {
+          pageSize: env.pluginOptions.pageSize,
+        }),
+      ),
+    ),
   )

--- a/packages/gatsby-source-prismic/src/plugin-options-schema.ts
+++ b/packages/gatsby-source-prismic/src/plugin-options-schema.ts
@@ -197,6 +197,9 @@ export const pluginOptionsSchema: NonNullable<
     fetchLinks: Joi.array().items(Joi.string().required()),
     graphQuery: Joi.string(),
     lang: Joi.string().default(DEFAULT_LANG),
+    // TODO: Remove the hardcoded default once this PR to @prismicio/client is merged:
+    // https://github.com/prismicio/prismic-client/pull/195
+    pageSize: Joi.number().default(100),
     linkResolver: Joi.function(),
     htmlSerializer: Joi.function(),
     schemas: Joi.object(),
@@ -209,8 +212,8 @@ export const pluginOptionsSchema: NonNullable<
     createRemoteFileNode: Joi.function().default(
       () => gatsbyFs.createRemoteFileNode,
     ),
-    transformFieldName: Joi.function().default(() => (fieldName: string) =>
-      fieldName.replace(/-/g, '_'),
+    transformFieldName: Joi.function().default(
+      () => (fieldName: string) => fieldName.replace(/-/g, '_'),
     ),
     fetch: Joi.function().default(() => fetch),
   })

--- a/packages/gatsby-source-prismic/src/types.ts
+++ b/packages/gatsby-source-prismic/src/types.ts
@@ -72,6 +72,7 @@ export interface PluginOptions extends gatsby.PluginOptions {
   graphQuery?: string
   fetchLinks?: string[]
   lang: string
+  pageSize?: number
   linkResolver?: prismicH.LinkResolverFunction
   htmlSerializer?: prismicH.HTMLFunctionSerializer | prismicH.HTMLMapSerializer
   schemas: Record<string, prismicT.CustomTypeModelDefinition>
@@ -86,7 +87,7 @@ export interface PluginOptions extends gatsby.PluginOptions {
 }
 
 export type FieldConfigCreator<
-  TSchema extends prismicT.CustomTypeModelField = prismicT.CustomTypeModelField
+  TSchema extends prismicT.CustomTypeModelField = prismicT.CustomTypeModelField,
 > = (
   path: string[],
   schema: TSchema,
@@ -188,7 +189,7 @@ interface PrismicWebhookExperimentVariation {
 export type PrismicCustomTypeApiResponse = PrismicCustomTypeApiCustomType[]
 
 export interface PrismicCustomTypeApiCustomType<
-  Model extends prismicT.CustomTypeModel = prismicT.CustomTypeModel
+  Model extends prismicT.CustomTypeModel = prismicT.CustomTypeModel,
 > {
   id: string
   label: string

--- a/packages/gatsby-source-prismic/test/__testutils__/createPluginOptions.ts
+++ b/packages/gatsby-source-prismic/test/__testutils__/createPluginOptions.ts
@@ -24,6 +24,7 @@ export const createPluginOptions = (t: ava.ExecutionContext): PluginOptions => {
     typePrefix: 'prefix',
     schemas: {},
     lang: DEFAULT_LANG,
+    pageSize: 100,
     webhookSecret: 'secret',
     imageImgixParams: DEFAULT_IMGIX_PARAMS,
     imagePlaceholderImgixParams: DEFAULT_PLACEHOLDER_IMGIX_PARAMS,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2919,20 +2919,19 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
   integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
 
-"@prismicio/client@6.0.0-beta.0":
-  version "6.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/@prismicio/client/-/client-6.0.0-beta.0.tgz#b43a207775bfc2f70a3d30138ad239a689bf5acf"
-  integrity sha512-MGKxEao/CeqjuBaKrNovtoFl6D/EClfHnCBaL8c50nD2kQJz8BziC8cHUAw/8eWqEFnJXLvLCP5NKiks+s3log==
+"@prismicio/client@6.0.0-alpha.8":
+  version "6.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/@prismicio/client/-/client-6.0.0-alpha.8.tgz#fdd086032e823b964ef63651b4a2aa9bedf29109"
+  integrity sha512-zp3c8mZ/Sm2tQdZCASGEEx2UGJnYS1elFwTEca7M2y/Qi3hPM+Agp4xNMM5UoAg+2m1VFAt151vfaEscc5q4Gw==
   dependencies:
-    "@prismicio/helpers" "^2.0.0-alpha.9"
-    "@prismicio/types" "^0.1.13"
+    "@prismicio/helpers" "^2.0.0-alpha.3"
 
 "@prismicio/custom-types-client@^0.0.6":
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/@prismicio/custom-types-client/-/custom-types-client-0.0.6.tgz#774e1498b88a07b817292a5894208851c5dd4635"
   integrity sha512-/QeHmNzEtOMtEAZF7ZfRSSosSXGhA4dzQm7vczhxdBGIT23Bbj+h0I4hNlpJZ4n0UzmIYWtd45jYCguVo3hfqQ==
 
-"@prismicio/helpers@^2.0.0-alpha.9", "@prismicio/helpers@^2.0.0-beta.0":
+"@prismicio/helpers@^2.0.0-alpha.3", "@prismicio/helpers@^2.0.0-beta.0":
   version "2.0.0-beta.0"
   resolved "https://registry.yarnpkg.com/@prismicio/helpers/-/helpers-2.0.0-beta.0.tgz#493d07f81bde06d76928af94e99672ac9f429962"
   integrity sha512-2WLXcS9Q/8JU7maNo/3cUSsUKnjUMpuZTxVxCSaDxDcBACrXR3T2nSJKvzcO5jS5zzpAkJG6zCdjP3dQVRwPmw==


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Package

<!--- Which packages are affected? Put an `x` in all the boxes that apply: -->

- [x] gatsby-source-prismic
- [x] gatsby-plugin-prismic-previews

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Adds a `pageSize` plugin option to `gatsby-source-prismic` and `gatsby-plugin-prismic-previews` which allows setting the `pageSize` option to `@prismicio/client`.

This allows a user to reduce API payloads during node sourcing by setting the page size to less than the maximum (100). This may be necessary if the Prismic REST API fails the request due to result that is larger than the maximum payload size.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
