### PR TITLE
fix: ensure cached localFile fields are not null

### DIFF
--- a/packages/gatsby-source-prismic/src/builders/buildImageBaseFieldConfigMap.ts
+++ b/packages/gatsby-source-prismic/src/builders/buildImageBaseFieldConfigMap.ts
@@ -23,7 +23,7 @@ import { Dependencies } from "../types";
 const resolveUrl = (source: prismicT.ImageField): string | null =>
 	source.url
 		? sanitizeImageURL(stripURLQueryParameters(source.url))
-		: source.url;
+		: source.url ?? null;
 
 /**
  * Returns the width of an image from the value of an Image field.

--- a/packages/gatsby-source-prismic/src/lib/createRemoteFileNode.ts
+++ b/packages/gatsby-source-prismic/src/lib/createRemoteFileNode.ts
@@ -7,6 +7,7 @@ import { pipe } from "fp-ts/function";
 import { Dependencies } from "../types";
 import { shouldDownloadFile } from "./shouldDownloadFile";
 import { getFromOrSetToCache } from "./getFromOrSetToCache";
+import { touchNode } from "./touchNode";
 
 type CreateRemoteFileNodeConfig = {
 	url: string;
@@ -55,4 +56,5 @@ export const createRemoteFileNode = (
 				),
 			),
 		),
+		RTE.chainFirst((node) => (node ? touchNode(node) : RTE.right(null))),
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Package

<!--- Which packages are affected? Put an `x` in all the boxes that apply: -->

- [x] gatsby-source-prismic
- [ ] gatsby-plugin-prismic-previews

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Data from Image and Link to Media fields can be downloaded locally and accessed via `localFile`. The downloaded file and its `File` node are cached.

Before this PR, the `File` node could sometimes be garbage collected, resulting in a `null` value for `localFile`. This PR ensures `File` node are not garbage collected by using the `touchNode` action.

Resolves: #471

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
🦕