### PR TITLE
feat: add `routes` option to support Route Resolver

### DIFF
--- a/packages/gatsby-plugin-prismic-previews/src/plugin-options-schema.ts
+++ b/packages/gatsby-plugin-prismic-previews/src/plugin-options-schema.ts
@@ -30,6 +30,13 @@ export const pluginOptionsSchema: NonNullable<
 		apiEndpoint: Joi.string().default((parent) =>
 			prismic.getEndpoint(parent.repositoryName),
 		),
+		routes: Joi.array().items(
+			Joi.object({
+				type: Joi.string().required(),
+				path: Joi.string().required(),
+				resolvers: Joi.object().pattern(Joi.string(), Joi.string().required()),
+			}),
+		),
 		graphQuery: Joi.string(),
 		fetchLinks: Joi.array().items(Joi.string().required()),
 		lang: Joi.string().default(DEFAULT_LANG),

--- a/packages/gatsby-plugin-prismic-previews/src/types.ts
+++ b/packages/gatsby-plugin-prismic-previews/src/types.ts
@@ -33,6 +33,7 @@ export interface PluginOptions extends gatsby.PluginOptions {
 	accessToken?: string;
 	promptForAccessToken?: boolean;
 	apiEndpoint: string;
+	routes?: prismic.Route[];
 	graphQuery?: string;
 	fetchLinks?: string[];
 	lang: string;

--- a/packages/gatsby-plugin-prismic-previews/src/usePrismicPreviewBootstrap.ts
+++ b/packages/gatsby-plugin-prismic-previews/src/usePrismicPreviewBootstrap.ts
@@ -157,6 +157,7 @@ export const usePrismicPreviewBootstrap = (
 			prismic.getEndpoint(repositoryName.value);
 		const client = prismic.createClient(endpoint, {
 			accessToken: repositoryPluginOptions.accessToken,
+			routes: repositoryPluginOptions.routes,
 			defaultParams: {
 				lang: repositoryPluginOptions.lang,
 				fetchLinks: repositoryPluginOptions.fetchLinks,

--- a/packages/gatsby-plugin-prismic-previews/src/usePrismicPreviewResolver.ts
+++ b/packages/gatsby-plugin-prismic-previews/src/usePrismicPreviewResolver.ts
@@ -108,6 +108,7 @@ export const usePrismicPreviewResolver = (
 			prismic.getEndpoint(repositoryName.value);
 		const client = prismic.createClient(endpoint, {
 			accessToken: repositoryPluginOptions.accessToken,
+			routes: repositoryPluginOptions.routes,
 			defaultParams: {
 				lang: repositoryPluginOptions.lang,
 				fetchLinks: repositoryPluginOptions.fetchLinks,

--- a/packages/gatsby-source-prismic/src/buildDependencies.ts
+++ b/packages/gatsby-source-prismic/src/buildDependencies.ts
@@ -28,6 +28,7 @@ export const buildDependencies = async (
 	const prismicClient = prismic.createClient(pluginOptions.apiEndpoint, {
 		fetch: pluginOptions.fetch,
 		accessToken: pluginOptions.accessToken,
+		routes: pluginOptions.routes,
 		defaultParams: {
 			lang: pluginOptions.lang,
 			fetchLinks: pluginOptions.fetchLinks,

--- a/packages/gatsby-source-prismic/src/plugin-options-schema.ts
+++ b/packages/gatsby-source-prismic/src/plugin-options-schema.ts
@@ -37,6 +37,13 @@ export const pluginOptionsSchema: NonNullable<
 		lang: Joi.string(),
 		pageSize: Joi.number(),
 		linkResolver: Joi.function(),
+		routes: Joi.array().items(
+			Joi.object({
+				type: Joi.string().required(),
+				path: Joi.string().required(),
+				resolvers: Joi.object().pattern(Joi.string(), Joi.string().required()),
+			}),
+		),
 		htmlSerializer: Joi.alternatives(
 			Joi.object().pattern(
 				Joi.allow(...Object.keys(prismicH.Element)),

--- a/packages/gatsby-source-prismic/src/types.ts
+++ b/packages/gatsby-source-prismic/src/types.ts
@@ -100,6 +100,7 @@ export type UnpreparedPluginOptions = gatsby.PluginOptions & {
 	lang?: string;
 	pageSize?: number;
 	linkResolver?: prismicH.LinkResolverFunction;
+	routes?: prismic.Route[];
 	htmlSerializer?: prismicH.HTMLFunctionSerializer | prismicH.HTMLMapSerializer;
 	imageImgixParams?: imgixGatsby.ImgixUrlParams;
 	imagePlaceholderImgixParams?: imgixGatsby.ImgixUrlParams;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Package

<!--- Which packages are affected? Put an `x` in all the boxes that apply: -->

- [x] gatsby-source-prismic
- [x] gatsby-plugin-prismic-previews

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds support for Route Resolvers via the `routes` option. To learn more about Route Resolver and how it compares to Link Resolver, see: https://prismic.io/docs/core-concepts/link-resolver-route-resolver

Note that if a `routes` option is given to `gatsby-source-prismic`, it should also be added to `gatsby-plugin-prismic-previews`. The option can be given to both plugins in exactly the same way.

Example `gatsby-config.js` with Route Resolvers:

```javascript
module.exports = {
  plugins: [
    {
      resolve: "gatsby-source-prismic",
      options: {
        repositoryName: "repo-name",
        routes: [
          {
            type: "page",
            path: "/:lang/:uid",
          },
          {
            type: "blog_post",
            path: "/:lang/blog/:category?/:uid",
            resolvers: {
              country: "country",
              category: "country.category",
            },
          },
        ],
      },
    },
  ],
};
```

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐳
