### PR TITLE
fix(source): exclude empty Slice Zones in GraphQL type

### DIFF
--- a/packages/gatsby-source-prismic/src/lib/buildFieldConfigMap.ts
+++ b/packages/gatsby-source-prismic/src/lib/buildFieldConfigMap.ts
@@ -42,4 +42,9 @@ export const buildFieldConfigMap = (
 				R.sequence(RTE.ApplicativeSeq),
 			),
 		),
+		RTE.map(
+			R.filter((fieldConfig): fieldConfig is NonNullable<typeof fieldConfig> =>
+				Boolean(fieldConfig),
+			),
+		),
 	);

--- a/packages/gatsby-source-prismic/src/lib/toFieldConfig.ts
+++ b/packages/gatsby-source-prismic/src/lib/toFieldConfig.ts
@@ -26,6 +26,9 @@ import { buildIntegrationFieldConfig } from "../builders/buildIntegrationFieldCo
  * Returns a GraphQL field configuration object for a Custom Type field. The
  * resulting configuration object can be used in a GraphQL type.
  *
+ * In some cases, `undefined` will be returned. Fields that return `undefined`
+ * should be omitted from the GraphQL schema.
+ *
  * @param path - Path to the field.
  * @param schema - Schema definition for the field.
  *
@@ -37,7 +40,7 @@ export const toFieldConfig = (
 ): RTE.ReaderTaskEither<
 	Dependencies,
 	Error,
-	gqlc.ObjectTypeComposerFieldConfigDefinition<unknown, unknown>
+	gqlc.ObjectTypeComposerFieldConfigDefinition<unknown, unknown> | undefined
 > => {
 	switch (schema.type) {
 		case prismicT.CustomTypeModelFieldType.Boolean: {
@@ -85,7 +88,11 @@ export const toFieldConfig = (
 		}
 
 		case prismicT.CustomTypeModelFieldType.Slices: {
-			return buildSlicesFieldConfig(path, schema);
+			if (Object.keys(schema.config.choices).length > 0) {
+				return buildSlicesFieldConfig(path, schema);
+			} else {
+				return RTE.right(undefined);
+			}
 		}
 
 		case prismicT.CustomTypeModelFieldType.StructuredText: {

--- a/packages/gatsby-source-prismic/test/create-schema-customization-slices.test.ts
+++ b/packages/gatsby-source-prismic/test/create-schema-customization-slices.test.ts
@@ -239,6 +239,43 @@ test("creates types for each slice choice", async (t) => {
 	);
 });
 
+test("slice zones with no slices are excluded from the custom type", async (t) => {
+	const gatsbyContext = createGatsbyContext();
+	const pluginOptions = createPluginOptions(t);
+
+	const customTypeModel = createMockCustomTypeModelWithFields(t, {
+		// Including an extra field so we have something to check for in the test.
+		keyText: prismicM.model.keyText({ seed: t.title }),
+		// This field should not be included in the Custom Type's type.
+		slices: prismicM.model.sliceZone({
+			seed: t.title,
+			choices: {},
+		}),
+	});
+	customTypeModel.id = "foo";
+
+	pluginOptions.customTypeModels = [customTypeModel];
+
+	await createSchemaCustomization(
+		gatsbyContext as gatsby.CreateSchemaCustomizationArgs,
+		pluginOptions,
+		noop,
+	);
+
+	t.true(
+		(gatsbyContext.actions.createTypes as sinon.SinonStub).calledWith({
+			kind: "OBJECT",
+			config: {
+				name: "PrismicPrefixFooDataType",
+				fields: {
+					keyText: "String",
+				},
+			},
+		}),
+		"The `slices` Slice Zone should not be included",
+	);
+});
+
 test("id field resolves to a unique id", async (t) => {
 	const gatsbyContext = createGatsbyContext();
 	const pluginOptions = createPluginOptions(t);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Package

<!--- Which packages are affected? Put an `x` in all the boxes that apply: -->

- [x] gatsby-source-prismic
- [ ] gatsby-plugin-prismic-previews

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Fixes #487

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🚋
