### PR TITLE
fix: support Shared Slices without primary/items models

### DIFF
--- a/packages/gatsby-source-prismic/src/runtime/typePaths.ts
+++ b/packages/gatsby-source-prismic/src/runtime/typePaths.ts
@@ -140,7 +140,7 @@ export const sharedSliceModelToTypePaths = <
 	transformFieldName: TransformFieldNameFn,
 ): TypePath[] => {
 	return sharedSliceModel.variations.flatMap((variation) => {
-		const primary = Object.entries(variation.primary).flatMap(
+		const primary = Object.entries(variation.primary || {}).flatMap(
 			([fieldId, fieldModel]) =>
 				fieldToTypePaths(
 					[
@@ -154,7 +154,7 @@ export const sharedSliceModelToTypePaths = <
 				),
 		);
 
-		const items = Object.entries(variation.items).flatMap(
+		const items = Object.entries(variation.items || {}).flatMap(
 			([fieldId, fieldModel]) =>
 				fieldToTypePaths(
 					[


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Package

<!--- Which packages are affected? Put an `x` in all the boxes that apply: -->

- [x] gatsby-source-prismic
- [ ] gatsby-plugin-prismic-previews

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Fixes #490

This adds support for Shared Slice models without `primary` or `items` models. This should be invalid, but it is possible to push and pull models to the Custom Types API without these fields.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🦙
