### PR TITLE
fix: remove default `q=50` Imgix parameter for Gatsby images

### DIFF
--- a/packages/gatsby-source-prismic/src/constants.ts
+++ b/packages/gatsby-source-prismic/src/constants.ts
@@ -43,7 +43,6 @@ export const DEFAULT_IMGIX_PARAMS = {
 
 	// The following values are not included by Prismic's URLs by default.
 	fit: "max",
-	q: 50,
 } as const;
 
 /**

--- a/packages/gatsby-source-prismic/test/runtime-image.test.ts
+++ b/packages/gatsby-source-prismic/test/runtime-image.test.ts
@@ -63,7 +63,6 @@ test("normalizes Image fields", (t) => {
 	const url = new URL(document.data.image.url!);
 	url.searchParams.set("fit", "max");
 	url.searchParams.set("auto", "compress,format");
-	url.searchParams.set("q", "50");
 
 	t.is(normalizedDocument.data.image.alt, document.data.image.alt);
 	t.is(normalizedDocument.data.image.url, decodeURIComponent(url.toString()));

--- a/packages/gatsby-source-prismic/test/runtime.test.ts
+++ b/packages/gatsby-source-prismic/test/runtime.test.ts
@@ -23,7 +23,6 @@ test("createRuntime creates a Runtime instance with default config", (t) => {
 	t.deepEqual(runtime.config.imageImgixParams, {
 		auto: "compress,format",
 		fit: "max",
-		q: 50,
 	});
 	t.deepEqual(runtime.config.imagePlaceholderImgixParams, {
 		w: 100,
@@ -39,7 +38,7 @@ test("config can be passed on creation", (t) => {
 		typePrefix: "typePrefix",
 		linkResolver: (doc) => `/${doc.uid}`,
 		htmlSerializer: { heading1: () => "heading1" },
-		imageImgixParams: { q: 50 },
+		imageImgixParams: { q: 60 },
 		imagePlaceholderImgixParams: { q: 30 },
 		transformFieldName: (fieldName) => fieldName,
 	};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Package

<!--- Which packages are affected? Put an `x` in all the boxes that apply: -->

- [x] gatsby-source-prismic
- [x] gatsby-plugin-prismic-previews

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR removes the default `q=50` Imgix URL parameter added to all images by `gatsby-source-prismic` and, by extension, `gatsby-plugin-prismic-previews`.

For more details on why this was changed, see: #498

Thanks to @jodiedoubleday for reporting this.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐈
