### PR TITLE
fix(previews): retain correct scroll position during preview bootstrapping

### DIFF
--- a/packages/gatsby-plugin-prismic-previews/src/components/Modal.tsx
+++ b/packages/gatsby-plugin-prismic-previews/src/components/Modal.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Dialog } from "@reach/dialog";
+import { DialogContent, DialogOverlay } from "@reach/dialog";
 import clsx from "clsx";
 
 import { Root } from "./Root";
@@ -62,45 +62,51 @@ export const Modal = ({
 	"aria-label": ariaLabel,
 }: ModalProps): JSX.Element => {
 	return (
-		<Dialog isOpen={isOpen} onDismiss={onDismiss} aria-label={ariaLabel}>
-			<Root>
-				<div className="z-max bg-black bg-opacity-60 fixed inset-0 overflow-auto">
-					<div className="w-full max-w-34rem mx-auto mt-20vh px-4">
-						<div
-							className={clsx(
-								"rounded-lg shadow-lg px-7 py-8 relative sm:px-10",
-								variant === "base" && "bg-white text-slate-30",
-								variant === "red" && "bg-red-40 text-white",
-							)}
-							data-gatsby-plugin-prismic-previews-repository-name={
-								repositoryName
-							}
-						>
-							<div className="grid gap-7">
-								<PrismicLogo
-									fillWhite={variant === "red"}
-									className="block mx-auto w-11 h-11"
-								/>
-								<div>{children}</div>
-							</div>
-
-							<button
+		<DialogOverlay
+			isOpen={isOpen}
+			onDismiss={onDismiss}
+			dangerouslyBypassFocusLock={true}
+		>
+			<DialogContent aria-label={ariaLabel}>
+				<Root>
+					<div className="z-max bg-black bg-opacity-60 fixed inset-0 overflow-auto">
+						<div className="w-full max-w-34rem mx-auto mt-20vh px-4">
+							<div
 								className={clsx(
-									"absolute top-5 right-5 transition  sm:top-6 sm:right-6 p-2 -m-2",
-									variant === "base" &&
-										"text-slate-90 hover:text-slate-60 focus:text-slate-60",
-									variant === "red" &&
-										"text-red-80 hover:text-white focus:text-white",
+									"rounded-lg shadow-lg px-7 py-8 relative sm:px-10",
+									variant === "base" && "bg-white text-slate-30",
+									variant === "red" && "bg-red-40 text-white",
 								)}
-								onClick={onDismiss}
+								data-gatsby-plugin-prismic-previews-repository-name={
+									repositoryName
+								}
 							>
-								<span className="sr-only">Close modal</span>
-								<CloseSVG className="w-5 h-5" />
-							</button>
+								<div className="grid gap-7">
+									<PrismicLogo
+										fillWhite={variant === "red"}
+										className="block mx-auto w-11 h-11"
+									/>
+									<div>{children}</div>
+								</div>
+
+								<button
+									className={clsx(
+										"absolute top-5 right-5 transition  sm:top-6 sm:right-6 p-2 -m-2",
+										variant === "base" &&
+											"text-slate-90 hover:text-slate-60 focus:text-slate-60",
+										variant === "red" &&
+											"text-red-80 hover:text-white focus:text-white",
+									)}
+									onClick={onDismiss}
+								>
+									<span className="sr-only">Close modal</span>
+									<CloseSVG className="w-5 h-5" />
+								</button>
+							</div>
 						</div>
 					</div>
-				</div>
-			</Root>
-		</Dialog>
+				</Root>
+			</DialogContent>
+		</DialogOverlay>
 	);
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Package

<!--- Which packages are affected? Put an `x` in all the boxes that apply: -->

- [ ] gatsby-source-prismic
- [x] gatsby-plugin-prismic-previews

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes an issue where the scroll position of the app is not the top of the page after a preview has gone through the bootstrap process. This would be seen at the start of a preview session (i.e. after the preview resolve page) or after refreshing an existing preview session.

This was due to `@reach/dialog`'s automatic focus trapping. Because the dialog is not positioned at the top of the page and includes a button which automatically gains focus, the scroll position was changed.

This PR removes the focus trapping capabilities of `@reach/dialog`.

(credit to @asyarb for reporting the issue and helping to find the fix)

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
