### PR TITLE
fix: normalize Shared Slices using a corrected refinement

### DIFF
--- a/packages/gatsby-source-prismic/src/lib/normalizeDocumentSubtree.ts
+++ b/packages/gatsby-source-prismic/src/lib/normalizeDocumentSubtree.ts
@@ -84,7 +84,7 @@ const sliceValueRefinement = (value: unknown): value is prismicT.Slice =>
 const sharedSliceValueRefinement = (
 	value: unknown,
 ): value is prismicT.SharedSlice =>
-	slicesValueRefinement(value) && "variation" in value;
+	sliceValueRefinement(value) && "variation" in value;
 
 /**
  * Determines if a value is a Slice Zone.


### PR DESCRIPTION
## Package


- [x] gatsby-source-prismic
- [ ] gatsby-plugin-prismic-previews

## Types of changes

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

We noticed our shared slice were not properly rendered in the graphQL explorer.
It seems the test to check wether a value was a SharedSlice is wrong as it tests if it's an array of value

## Checklist:

- [ ] My change requires an update to the official documentation.
- [ ] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.


