### PR TITLE
refactor(previews): improve performance for large repositories

### DIFF
--- a/packages/gatsby-plugin-prismic-previews/src/constants.ts
+++ b/packages/gatsby-plugin-prismic-previews/src/constants.ts
@@ -34,7 +34,7 @@ export const QUERY_PAGE_SIZE = 100;
 /**
  * Template used to generate a hash for a collection of type paths.
  */
-export const TYPE_PATHS_BASENAME_TEMPLATE = "type-paths-store %s";
+export const TYPE_PATHS_BASENAME_TEMPLATE = "type-paths___%s";
 
 /**
  * Identifier used to store plugin options on `window` to pass to other parts of

--- a/packages/gatsby-plugin-prismic-previews/src/lib/buildTypePathsStoreFilename.ts
+++ b/packages/gatsby-plugin-prismic-previews/src/lib/buildTypePathsStoreFilename.ts
@@ -1,5 +1,3 @@
-import md5 from "tiny-hashes/md5";
-
 import { TYPE_PATHS_BASENAME_TEMPLATE } from "../constants";
 import { sprintf } from "./sprintf";
 
@@ -8,5 +6,5 @@ export interface BuildTypePathsStoreFilenameEnv {
 }
 
 export const buildTypePathsStoreFilename = (repositoryName: string): string => {
-	return `${md5(sprintf(TYPE_PATHS_BASENAME_TEMPLATE, repositoryName))}.json`;
+	return `${sprintf(TYPE_PATHS_BASENAME_TEMPLATE, repositoryName)}.json`;
 };

--- a/packages/gatsby-plugin-prismic-previews/src/on-post-bootstrap.ts
+++ b/packages/gatsby-plugin-prismic-previews/src/on-post-bootstrap.ts
@@ -2,7 +2,6 @@ import * as gatsby from "gatsby";
 import * as gatsbyPrismic from "gatsby-source-prismic";
 import * as path from "path";
 import { createNodeHelpers } from "gatsby-node-helpers";
-import md5 from "tiny-hashes/md5";
 
 import { serializeTypePathNodes } from "./lib/serializeTypePathsNodes";
 import { sprintf } from "./lib/sprintf";
@@ -49,8 +48,9 @@ export const onPostBootstrap: NonNullable<
 
 	const serializedTypePaths = serializeTypePathNodes(typePathNodes);
 
-	const filename = `${md5(
-		sprintf(TYPE_PATHS_BASENAME_TEMPLATE, pluginOptions.repositoryName),
+	const filename = `${sprintf(
+		TYPE_PATHS_BASENAME_TEMPLATE,
+		pluginOptions.repositoryName,
 	)}.json`;
 	const publicPath = path.join("public", "static", filename);
 

--- a/packages/gatsby-plugin-prismic-previews/src/on-post-bootstrap.ts
+++ b/packages/gatsby-plugin-prismic-previews/src/on-post-bootstrap.ts
@@ -3,6 +3,7 @@ import * as gatsbyPrismic from "gatsby-source-prismic";
 import * as path from "path";
 import { createNodeHelpers } from "gatsby-node-helpers";
 
+import { buildTypePathsStoreFilename } from "./lib/buildTypePathsStoreFilename";
 import { serializeTypePathNodes } from "./lib/serializeTypePathsNodes";
 import { sprintf } from "./lib/sprintf";
 
@@ -10,7 +11,6 @@ import {
 	TYPE_PATHS_MISSING_NODE_MSG,
 	WROTE_TYPE_PATHS_TO_FS_MSG,
 	REPORTER_TEMPLATE,
-	TYPE_PATHS_BASENAME_TEMPLATE,
 } from "./constants";
 import { PluginOptions } from "./types";
 
@@ -48,10 +48,7 @@ export const onPostBootstrap: NonNullable<
 
 	const serializedTypePaths = serializeTypePathNodes(typePathNodes);
 
-	const filename = `${sprintf(
-		TYPE_PATHS_BASENAME_TEMPLATE,
-		pluginOptions.repositoryName,
-	)}.json`;
+	const filename = buildTypePathsStoreFilename(pluginOptions.repositoryName);
 	const publicPath = path.join("public", "static", filename);
 
 	await pluginOptions.writeTypePathsToFilesystem({

--- a/packages/gatsby-plugin-prismic-previews/test/__testutils__/createTypePathsMockedRequest.ts
+++ b/packages/gatsby-plugin-prismic-previews/test/__testutils__/createTypePathsMockedRequest.ts
@@ -4,10 +4,13 @@ import * as gatsbyPrismic from "gatsby-source-prismic";
 import { resolveURL } from "./resolveURL";
 
 export const createTypePathsMockedRequest = (
-	filename: string,
+	repositoryName: string,
 	typePaths: gatsbyPrismic.SerializedTypePath[],
 ): msw.RestHandler =>
 	msw.rest.get(
-		resolveURL(globalThis.__PATH_PREFIX__, `/static/${filename}`),
+		resolveURL(
+			globalThis.__PATH_PREFIX__,
+			`/static/type-paths___${repositoryName}.json`,
+		),
 		(_req, res, ctx) => res(ctx.json(typePaths)),
 	);

--- a/packages/gatsby-plugin-prismic-previews/test/on-post-bootstrap.test.ts
+++ b/packages/gatsby-plugin-prismic-previews/test/on-post-bootstrap.test.ts
@@ -35,7 +35,7 @@ test("saves serialized typepaths to filesystem", async (t) => {
 
 	t.is(
 		writeTypePathsToFilesystemCall.publicPath,
-		"public/static/3e66cce7662062ad5137e62e8bb62096.json",
+		`public/static/type-paths___${pluginOptions.repositoryName}.json`,
 	);
 
 	t.deepEqual(

--- a/packages/gatsby-plugin-prismic-previews/test/useMergePrismicPreviewData.test.ts
+++ b/packages/gatsby-plugin-prismic-previews/test/useMergePrismicPreviewData.test.ts
@@ -112,7 +112,7 @@ test.serial(
 				searchParams: { ref },
 			}),
 			createTypePathsMockedRequest(
-				"d26c1607b46a831c5d238303c3cbf489.json",
+				pluginOptions.repositoryName,
 				runtime.typePaths,
 			),
 		);
@@ -194,7 +194,7 @@ test("allows skipping", async (t) => {
 			searchParams: { ref },
 		}),
 		createTypePathsMockedRequest(
-			"87ec42108faaca92ab06c427cf0b3b9d.json",
+			pluginOptions.repositoryName,
 			runtime.typePaths,
 		),
 	);

--- a/packages/gatsby-plugin-prismic-previews/test/usePrismicPreviewBootstrap.test.ts
+++ b/packages/gatsby-plugin-prismic-previews/test/usePrismicPreviewBootstrap.test.ts
@@ -118,7 +118,7 @@ test.serial(
 				searchParams: { ref },
 			}),
 			createTypePathsMockedRequest(
-				"fa7e36097b060b84eb14d0df1009fa58.json",
+				pluginOptions.repositoryName,
 				runtime.typePaths,
 			),
 		);
@@ -187,7 +187,7 @@ test.serial("does nothing if already bootstrapped", async (t) => {
 			searchParams: { ref },
 		}),
 		createTypePathsMockedRequest(
-			"d6c42f6728e21ab594cd600ff04e4913.json",
+			pluginOptions.repositoryName,
 			runtime.typePaths,
 		),
 	);

--- a/packages/gatsby-plugin-prismic-previews/test/withPrismicPreview.test.tsx
+++ b/packages/gatsby-plugin-prismic-previews/test/withPrismicPreview.test.tsx
@@ -166,7 +166,7 @@ test.serial("merges data if preview data is available", async (t) => {
 			searchParams: { ref },
 		}),
 		createTypePathsMockedRequest(
-			"a9101d270279c16322571b8448d7a329.json",
+			pluginOptions.repositoryName,
 			runtime.typePaths,
 		),
 	);
@@ -231,7 +231,7 @@ test.serial("handles custom types without a data field", async (t) => {
 			searchParams: { ref },
 		}),
 		createTypePathsMockedRequest(
-			"eac4669530f66bef76da4016f1111055.json",
+			pluginOptions.repositoryName,
 			runtime.typePaths,
 		),
 	);

--- a/packages/gatsby-plugin-prismic-previews/test/withPrismicUnpublishedPreview.test.tsx
+++ b/packages/gatsby-plugin-prismic-previews/test/withPrismicUnpublishedPreview.test.tsx
@@ -192,7 +192,7 @@ test.serial("merges data if preview data is available", async (t) => {
 			searchParams: { ref },
 		}),
 		createTypePathsMockedRequest(
-			"a9101d270279c16322571b8448d7a329.json",
+			pluginOptions.repositoryName,
 			runtime.typePaths,
 		),
 	);

--- a/packages/gatsby-source-prismic/package.json
+++ b/packages/gatsby-source-prismic/package.json
@@ -52,8 +52,7 @@
 		"fp-ts": "^2.10.5",
 		"gatsby-node-helpers": "^1.2.1",
 		"gatsby-source-filesystem": "^4.0.0",
-		"node-fetch": "^2.6.5",
-		"tiny-hashes": "^1.0.1"
+		"node-fetch": "^2.6.5"
 	},
 	"devDependencies": {
 		"@prismicio/mock": "^0.0.6",

--- a/packages/gatsby-source-prismic/src/runtime/runtime.ts
+++ b/packages/gatsby-source-prismic/src/runtime/runtime.ts
@@ -22,7 +22,7 @@ import { serializeTypePaths } from "./serializeTypePaths";
 import { serializePath } from "./serializePath";
 
 // `createNodeId` would normally create a hash from its input, but we can treat
-// it as an identify function since we are using it within the context of
+// it as an identity function since we are using it within the context of
 // Prismic documents with unique IDs.
 const createNodeId = (input: string): string => input;
 

--- a/packages/gatsby-source-prismic/src/runtime/runtime.ts
+++ b/packages/gatsby-source-prismic/src/runtime/runtime.ts
@@ -28,7 +28,7 @@ const createNodeId = (input: string): string => input;
 
 // `createContentDigest` would normally create a hash from its input, but we
 // can treat it as a stubbed function since a Gatsby node's
-// `internal.contentDigest` property is an internal document. In a runtime
+// `internal.contentDigest` property is an internal field. In a runtime
 // preview, we don't need the digest.
 const createContentDigest = <T>(_input: T): string =>
 	"contentDigest is not supported during previews";

--- a/packages/gatsby-source-prismic/src/runtime/runtime.ts
+++ b/packages/gatsby-source-prismic/src/runtime/runtime.ts
@@ -3,7 +3,6 @@ import * as prismicH from "@prismicio/helpers";
 import * as imgixGatsby from "@imgix/gatsby";
 import * as nodeHelpers from "gatsby-node-helpers";
 import { pipe } from "fp-ts/function";
-import md5 from "tiny-hashes/md5";
 
 import { SerializedTypePath, TransformFieldNameFn, TypePath } from "../types";
 import { normalize } from "./normalize";
@@ -22,8 +21,17 @@ import { NormalizedDocumentValue } from "./normalizers";
 import { serializeTypePaths } from "./serializeTypePaths";
 import { serializePath } from "./serializePath";
 
-const createNodeId = (input: string): string => md5(input);
-const createContentDigest = <T>(input: T): string => md5(JSON.stringify(input));
+// `createNodeId` would normally create a hash from its input, but we can treat
+// it as an identify function since we are using it within the context of
+// Prismic documents with unique IDs.
+const createNodeId = (input: string): string => input;
+
+// `createContentDigest` would normally create a hash from its input, but we
+// can treat it as a stubbed function since a Gatsby node's
+// `internal.contentDigest` property is an internal document. In a runtime
+// preview, we don't need the digest.
+const createContentDigest = <T>(_input: T): string =>
+	"contentDigest is not supported during previews";
 
 export type RuntimeConfig = {
 	typePrefix?: string;

--- a/packages/gatsby-source-prismic/src/runtime/serializePath.ts
+++ b/packages/gatsby-source-prismic/src/runtime/serializePath.ts
@@ -1,4 +1,1 @@
-import md5 from "tiny-hashes/md5";
-
-export const serializePath = (path: string[]): string =>
-	process.env.NODE_ENV === "production" ? md5(path.join(".")) : path.join(".");
+export const serializePath = (path: string[]): string => path.join(".");

--- a/packages/gatsby-source-prismic/test/__testutils__/createPluginOptions.ts
+++ b/packages/gatsby-source-prismic/test/__testutils__/createPluginOptions.ts
@@ -1,13 +1,13 @@
 import * as ava from "ava";
 import * as sinon from "sinon";
-import * as crypto from "crypto";
 
 import { UnpreparedPluginOptions } from "../../src/types";
+import { md5 } from "./md5";
 
 export const createPluginOptions = (
 	t: ava.ExecutionContext,
 ): UnpreparedPluginOptions => {
-	const repositoryName = crypto.createHash("md5").update(t.title).digest("hex");
+	const repositoryName = md5(t.title);
 
 	return {
 		repositoryName,

--- a/packages/gatsby-source-prismic/test/__testutils__/createPrismicAPIDocument.ts
+++ b/packages/gatsby-source-prismic/test/__testutils__/createPrismicAPIDocument.ts
@@ -1,5 +1,6 @@
 import * as prismicT from "@prismicio/types";
-import md5 from "tiny-hashes/md5";
+
+import { md5 } from "./md5";
 
 const createId = () => md5(Math.random().toString());
 

--- a/packages/gatsby-source-prismic/test/__testutils__/md5.ts
+++ b/packages/gatsby-source-prismic/test/__testutils__/md5.ts
@@ -1,0 +1,5 @@
+import * as crypto from "crypto";
+
+export const md5 = (input: string): string => {
+	return crypto.createHash("md5").update(input).digest("hex");
+};

--- a/packages/gatsby-source-prismic/types/tiny-hashes.d.ts
+++ b/packages/gatsby-source-prismic/types/tiny-hashes.d.ts
@@ -1,3 +1,0 @@
-declare module "tiny-hashes/md5" {
-	export default function md5(str: string): string;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9688,7 +9688,7 @@ gatsby-plugin-page-creator@^4.0.0, gatsby-plugin-page-creator@^4.1.0:
     lodash "^4.17.21"
 
 "gatsby-plugin-prismic-previews@link:packages/gatsby-plugin-prismic-previews":
-  version "5.2.5"
+  version "5.2.6"
   dependencies:
     "@imgix/gatsby" "^1.7.5"
     "@prismicio/client" "^6.4.2"
@@ -9824,7 +9824,7 @@ gatsby-source-filesystem@^4.0.0:
     xstate "^4.14.0"
 
 "gatsby-source-prismic@link:packages/gatsby-source-prismic":
-  version "5.2.5"
+  version "5.2.6"
   dependencies:
     "@imgix/gatsby" "^1.7.5"
     "@prismicio/client" "^6.4.2"
@@ -9836,7 +9836,6 @@ gatsby-source-filesystem@^4.0.0:
     gatsby-node-helpers "^1.2.1"
     gatsby-source-filesystem "^4.0.0"
     node-fetch "^2.6.5"
-    tiny-hashes "^1.0.1"
 
 gatsby-telemetry@^3.0.0, gatsby-telemetry@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Package

<!--- Which packages are affected? Put an `x` in all the boxes that apply: -->

- [x] gatsby-source-prismic
- [x] gatsby-plugin-prismic-previews

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR improves performance during previews orchistrated by `gatsby-plugin-prismic-previews`. The performance improvement is negligible for relatively small repositories, but should be noticable to large repositories (>500 documents).

Note that this does not fundamentally change the way previews work; it will still fetch all documents in the repository to ensure near identical behavior to the Gatsby's native GraphQL API.

The changes in this PR remove extra computation that is not critical during client-side previews.

For more details, see #500.

(Thank you to @Baztoune for diagnosing the issue and finding a fix. Also, thank you to everyone who has reported the issue in #500 and shared their experience.)

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [ ] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
