### PR TITLE
fix(previews): support React 18

### DIFF
--- a/packages/gatsby-plugin-prismic-previews/package.json
+++ b/packages/gatsby-plugin-prismic-previews/package.json
@@ -115,7 +115,7 @@
 		"gatsby": "^3.0.0-next.0 || ^4.0.0-next.0",
 		"gatsby-plugin-image": "^1.3.0-next.1 || ^2.0.0-next.0",
 		"gatsby-source-prismic": "^5.0.0",
-		"react": "^16.9.0 || ^17.0.0"
+		"react": "^16.9.0 || ^17 || ^18"
 	},
 	"engines": {
 		"node": ">=12.7.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Package

<!--- Which packages are affected? Put an `x` in all the boxes that apply: -->

- [ ] gatsby-source-prismic
- [x] gatsby-plugin-prismic-previews

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds support for React 18 in `gatsby-plugin-prismic-previews`.

No functional changes were required, just a `peerDependency` update.

Fixes #507

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
