### PR TITLE
fix(source): support Slice Zones with missing `choices` property

### DIFF
--- a/packages/gatsby-source-prismic/src/lib/toFieldConfig.ts
+++ b/packages/gatsby-source-prismic/src/lib/toFieldConfig.ts
@@ -88,7 +88,10 @@ export const toFieldConfig = (
 		}
 
 		case prismicT.CustomTypeModelFieldType.Slices: {
-			if (Object.keys(schema.config.choices).length > 0) {
+			if (
+				schema.config.choices &&
+				Object.keys(schema.config.choices).length > 0
+			) {
 				return buildSlicesFieldConfig(path, schema);
 			} else {
 				return RTE.right(undefined);

--- a/packages/gatsby-source-prismic/src/runtime/typePaths.ts
+++ b/packages/gatsby-source-prismic/src/runtime/typePaths.ts
@@ -33,7 +33,10 @@ const fieldToTypePaths = <
 		}
 
 		case prismicT.CustomTypeModelFieldType.Slices: {
-			const choices = Object.entries(model.config.choices)
+			const choices = (
+				(model.config.choices && Object.entries(model.config.choices)) ||
+				[]
+			)
 				.filter(
 					(entry): entry is [string, prismicT.CustomTypeModelSlice] =>
 						entry[1].type === prismicT.CustomTypeModelSliceType.Slice,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Package

<!--- Which packages are affected? Put an `x` in all the boxes that apply: -->

- [x] gatsby-source-prismic
- [ ] gatsby-plugin-prismic-previews

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a bug where Gatsby's `createSchemaCustomization` step would throw if a Custom Type's Slice Zone was missing a `choices` property. This can happen if a Slice Zone is enabled, but no Slices are added.

Note that bug is different than `{ choices: {} }`, which was fixed in [`v5.2.4`](https://github.com/prismicio/prismic-gatsby/commit/23cb1316dd081249ec1788c6963eeba0a3e2c077).

(Thanks to @a-trost for reporting the bug!)

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
