### PR TITLE
feat(v3): add `pageSize` plugin option

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -63,6 +63,7 @@ export const fetchAllDocuments = async (
     accessToken,
     fetchLinks,
     lang,
+    pageSize,
   } = pluginOptions
   const { reporter } = gatsbyContext
 
@@ -84,7 +85,14 @@ export const fetchAllDocuments = async (
   if (fetchLinks) queryOptions.fetchLinks = fetchLinks
   if (lang) queryOptions.lang = lang
 
-  return await pagedGet(client, queryOptions, 1, API_PAGE_SIZE, [], reporter)
+  return await pagedGet(
+    client,
+    queryOptions,
+    1,
+    pageSize || API_PAGE_SIZE,
+    [],
+    reporter,
+  )
 }
 
 export async function fetchDocumentsByIds(

--- a/src/types.ts
+++ b/src/types.ts
@@ -361,6 +361,7 @@ export interface PluginOptions extends GatsbyPluginOptions {
   fetchLinks?: string[]
   schemas: Schemas
   lang?: string
+  pageSize?: number
   shouldDownloadImage?: ShouldDownloadImage
   shouldNormalizeImage?: ShouldDownloadImage
   typePathsFilenamePrefix?: string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Package

<!--- Which packages are affected? Put an `x` in all the boxes that apply: -->

- [x] gatsby-source-prismic
- [ ] gatsby-plugin-prismic-previews

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR backports the `pageSize` plugin option from v4+ to v3.

The `pageSize` plugin option is described as such in the `gatsby-source-prismic` v5 documentation:

> Set the maximum page size used when fetching documents from the Prismic API. If you are reaching API limits due to large documents, set this to a number less than the maximum (100). By default, the maximum page size of 100 is used.

Setting `pageSize` to a value less than the maximum (100) is necessary in cases where the query response exceeds Prismic's Rest API maximum payload size.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
