### PR TITLE
fix: update `@imgix/gatsby` to support Gatsby v5.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.3.1-alpha.0](https://github.com/prismicio/prismic-gatsby/compare/v5.3.0...v5.3.1-alpha.0) (2023-05-26)
+
+
+### Bug Fixes
+
+* update `@imgix/gatsby` to support Gatsby v5.10.0 ([0aaf43b](https://github.com/prismicio/prismic-gatsby/commit/0aaf43bdf2bb6ec601cad4f31b05bf603f085f8a))
+
+
+
+
+
 # [5.3.0](https://github.com/prismicio/prismic-gatsby/compare/v5.2.10...v5.3.0) (2023-03-14)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "5.3.0",
+  "version": "5.3.1-alpha.0",
   "command": {
     "publish": {
       "conventionalCommits": true

--- a/packages/gatsby-plugin-prismic-previews/CHANGELOG.md
+++ b/packages/gatsby-plugin-prismic-previews/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.3.1-alpha.0](https://github.com/prismicio/prismic-gatsby/compare/v5.3.0...v5.3.1-alpha.0) (2023-05-26)
+
+
+### Bug Fixes
+
+* update `@imgix/gatsby` to support Gatsby v5.10.0 ([0aaf43b](https://github.com/prismicio/prismic-gatsby/commit/0aaf43bdf2bb6ec601cad4f31b05bf603f085f8a))
+
+
+
+
+
 # [5.3.0](https://github.com/prismicio/prismic-gatsby/compare/v5.2.10...v5.3.0) (2023-03-14)
 
 

--- a/packages/gatsby-plugin-prismic-previews/package.json
+++ b/packages/gatsby-plugin-prismic-previews/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gatsby-plugin-prismic-previews",
-	"version": "5.3.0",
+	"version": "5.3.1-alpha.0",
 	"description": "Gatsby plugin for integrating client-side Prismic previews support",
 	"keywords": [
 		"gatsby",

--- a/packages/gatsby-plugin-prismic-previews/package.json
+++ b/packages/gatsby-plugin-prismic-previews/package.json
@@ -48,7 +48,7 @@
 		"unit": "nyc ava"
 	},
 	"dependencies": {
-		"@imgix/gatsby": "^1.7.5",
+		"@imgix/gatsby": "^2.1.3",
 		"@prismicio/client": "^6.4.2",
 		"@prismicio/helpers": "^2.3.4",
 		"@prismicio/types": "^0.1.27",

--- a/packages/gatsby-source-prismic/CHANGELOG.md
+++ b/packages/gatsby-source-prismic/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.3.1-alpha.0](https://github.com/prismicio/prismic-gatsby/compare/v5.3.0...v5.3.1-alpha.0) (2023-05-26)
+
+
+### Bug Fixes
+
+* update `@imgix/gatsby` to support Gatsby v5.10.0 ([0aaf43b](https://github.com/prismicio/prismic-gatsby/commit/0aaf43bdf2bb6ec601cad4f31b05bf603f085f8a))
+
+
+
+
+
 # [5.3.0](https://github.com/prismicio/prismic-gatsby/compare/v5.2.10...v5.3.0) (2023-03-14)
 
 

--- a/packages/gatsby-source-prismic/package.json
+++ b/packages/gatsby-source-prismic/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gatsby-source-prismic",
-	"version": "5.3.0",
+	"version": "5.3.1-alpha.0",
 	"description": "Gatsby source plugin for building websites using Prismic as a data source",
 	"keywords": [
 		"gatsby",

--- a/packages/gatsby-source-prismic/package.json
+++ b/packages/gatsby-source-prismic/package.json
@@ -43,7 +43,7 @@
 		"unit": "nyc ava"
 	},
 	"dependencies": {
-		"@imgix/gatsby": "^1.7.5",
+		"@imgix/gatsby": "^2.1.3",
 		"@prismicio/client": "^6.4.2",
 		"@prismicio/custom-types-client": "^0.0.7",
 		"@prismicio/helpers": "^2.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1907,33 +1907,32 @@
   resolved "https://registry.yarnpkg.com/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz#98c23c950a3d9b6c8f0daed06da6c3af06981340"
   integrity sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==
 
-"@imgix/gatsby@^1.7.5":
-  version "1.7.7"
-  resolved "https://registry.yarnpkg.com/@imgix/gatsby/-/gatsby-1.7.7.tgz#39c7bc3bdbaa7054f26a9ddccaa3f8f446e71365"
-  integrity sha512-whtfK5itnwAN0p7Cy9BmSTvGU/TwoNwg8Yxgie55uGbRYqqmCqql8LMYHN3gA8+d8izYif8IUK7Fm57Zbkzo8g==
+"@imgix/gatsby@^2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@imgix/gatsby/-/gatsby-2.1.3.tgz#c8d297b3cd18b6a0c9af7685e48f03f4af3ea294"
+  integrity sha512-K1EB51uXC7sc03kDPkTmMA95ms1VpSQI8SAIaN1Ip91TNhc9OzWhc4VNo9B1hrI8QD4rTvfmb230o8NctF2svw==
   dependencies:
-    "@imgix/js-core" "3.2.2"
+    "@imgix/js-core" "3.6.0"
     camel-case "^4.1.2"
     common-tags "^1.8.0"
     debug "^4.3.1"
-    fp-ts "^2.9.3"
-    fp-ts-contrib "^0.1.18"
     graphql-compose "^9.0.0"
-    imgix-url-params "^11.11.2"
-    io-ts "^2.2.13"
-    io-ts-reporters "^1.2.2"
+    imgix-url-params "^11.15.0"
+    joi "^17.6.0"
     jsuri "^1.3.1"
+    lodash.get "^4.4.2"
     node-fetch "^2.6.0"
     ramda "^0.27.1"
-    read-pkg-up "^7.0.1"
+    read-pkg-up "^9.0.0"
 
-"@imgix/js-core@3.2.2":
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/@imgix/js-core/-/js-core-3.2.2.tgz#96484efe6c7176bb3ca2d4be48384ce022fcfba0"
-  integrity sha512-FtgDn0IRCS+qchQJCpYdTWi2ijRbYci/8QihFSbDE1sAuf6/udrq8meyhrextkhcTxSy3fIFEBpLPHYItXChYg==
+"@imgix/js-core@3.6.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@imgix/js-core/-/js-core-3.6.0.tgz#fea27da03696264fe0fa4d6f74e928b9e17fc764"
+  integrity sha512-00qsHfyk7HvSj5NJdLA5O2QeBUVPM0khpO0qQvyMBmVP9aZaYJWkMd1IXQm0TUvcI1+Ja2mvdPzRYULFCiQBTg==
   dependencies:
     js-base64 "~3.7.0"
     md5 "^2.2.1"
+    ufo "^0.7.10"
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -4761,7 +4760,7 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.66.tgz#dd035d409df322acc83dff62a602f12a5783bbb3"
   integrity sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==
 
-"@types/normalize-package-data@^2.4.0":
+"@types/normalize-package-data@^2.4.0", "@types/normalize-package-data@^2.4.1":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
   integrity sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
@@ -10292,6 +10291,14 @@ find-up@^5.0.0:
     locate-path "^6.0.0"
     path-exists "^4.0.0"
 
+find-up@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-6.3.0.tgz#2abab3d3280b2dc7ac10199ef324c4e002c8c790"
+  integrity sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==
+  dependencies:
+    locate-path "^7.1.0"
+    path-exists "^5.0.0"
+
 flat-cache@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
@@ -10424,12 +10431,7 @@ forwarded@0.2.0:
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
   integrity sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==
 
-fp-ts-contrib@^0.1.18:
-  version "0.1.29"
-  resolved "https://registry.yarnpkg.com/fp-ts-contrib/-/fp-ts-contrib-0.1.29.tgz#5d3c07bab21bb1c0491ca8d6f82d75fc7463b0cf"
-  integrity sha512-y+f+xlZqYgj2t+Alu/oat10UC491PByvH7XrT0ITc/DbDJK7LDJLShZJy2orjE7PlcJkO5niDenc1A/woyeB/Q==
-
-fp-ts@^2.10.5, fp-ts@^2.9.3:
+fp-ts@^2.10.5:
   version "2.12.3"
   resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.12.3.tgz#d991b1e8467d325dadbb6b0ab9524f773e9c3c49"
   integrity sha512-8m0XvW8kZbfnJOA4NvSVXu95mLbPf4LQGwQyqVukIYS4KzSNJiyKSmuZUmbVHteUi6MGkAJGPb0goPZqI+Tsqg==
@@ -10753,9 +10755,9 @@ gatsby-plugin-page-creator@^5.7.0:
     lodash "^4.17.21"
 
 "gatsby-plugin-prismic-previews@link:packages/gatsby-plugin-prismic-previews":
-  version "5.2.10"
+  version "5.3.0"
   dependencies:
-    "@imgix/gatsby" "^1.7.5"
+    "@imgix/gatsby" "^2.1.3"
     "@prismicio/client" "^6.4.2"
     "@prismicio/helpers" "^2.3.4"
     "@prismicio/types" "^0.1.27"
@@ -10841,9 +10843,9 @@ gatsby-source-filesystem@^5.0.0:
     xstate "^4.35.3"
 
 "gatsby-source-prismic@link:packages/gatsby-source-prismic":
-  version "5.2.10"
+  version "5.3.0"
   dependencies:
-    "@imgix/gatsby" "^1.7.5"
+    "@imgix/gatsby" "^2.1.3"
     "@prismicio/client" "^6.4.2"
     "@prismicio/custom-types-client" "^0.0.7"
     "@prismicio/helpers" "^2.3.4"
@@ -12104,10 +12106,10 @@ imgix-url-builder@^0.0.3:
   resolved "https://registry.yarnpkg.com/imgix-url-builder/-/imgix-url-builder-0.0.3.tgz#9f386de64cdd1363d352a7f6313fd7dacd8fb282"
   integrity sha512-8Oc2Cn4+jF06sEfJcVPlWYfD2F6RjrwIMbk1xEzux8unoB5LsvFc/GL1BQ47HPaeE12ReX2nMUcjUslGYWLxHA==
 
-imgix-url-params@^11.11.2:
-  version "11.13.0"
-  resolved "https://registry.yarnpkg.com/imgix-url-params/-/imgix-url-params-11.13.0.tgz#beec57f612005004f5111d43101a34d5ae86fddc"
-  integrity sha512-GSt+jzX+h5CNuypBzHDDCdNT/PRdSwvK/zqYL47ATvEYuNO6lXwJL83Q97hiZVb3NO2HfP3sH7MVq6so9gEZWw==
+imgix-url-params@^11.15.0:
+  version "11.15.0"
+  resolved "https://registry.yarnpkg.com/imgix-url-params/-/imgix-url-params-11.15.0.tgz#fa43b16a7e589bc20f4e646098246a70827de2cb"
+  integrity sha512-W8JprYztwdFTtNLTa/aj2PGh8CJNBaMKrTtgOYlo8OvJrRn3XELRTeZoLyob5C49qW9aFiIYIIqm8zWysRFu8g==
 
 immer@^9.0.7:
   version "9.0.15"
@@ -12313,16 +12315,6 @@ invariant@^2.2.4:
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
   dependencies:
     loose-envify "^1.0.0"
-
-io-ts-reporters@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/io-ts-reporters/-/io-ts-reporters-1.2.2.tgz#4d3219777ea5219c7d8f6ffac01fd68e72426dd1"
-  integrity sha512-igASwWWkDY757OutNcM6zTtdJf/eTZYkoe2ymsX2qpm5bKZLo74FJYjsCtMQOEdY7dRHLLEulCyFQwdN69GBCg==
-
-io-ts@^2.2.13:
-  version "2.2.18"
-  resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-2.2.18.tgz#dfb41aded5f0e598ccf2a25a483c205444210173"
-  integrity sha512-3JxUUzRtPQPs5sOwB7pW0+Xb54nOzqA6M1sRB1hwgsRmkWMeGTjtOrCynGTJhIj+mBLUj2S37DAq2+BrPh9kTQ==
 
 ip@^2.0.0:
   version "2.0.0"
@@ -13103,6 +13095,17 @@ jju@~1.4.0:
   resolved "https://registry.yarnpkg.com/jju/-/jju-1.4.0.tgz#a3abe2718af241a2b2904f84a625970f389ae32a"
   integrity sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==
 
+joi@^17.6.0:
+  version "17.9.2"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.9.2.tgz#8b2e4724188369f55451aebd1d0b1d9482470690"
+  integrity sha512-Itk/r+V4Dx0V3c7RLFdRh12IOjySm2/WGPMubBT92cQvRfYZhPM2W0hZlctjj72iES8jsRCwp7S/cRmWBnJ4nw==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+    "@hapi/topo" "^5.0.0"
+    "@sideway/address" "^4.1.3"
+    "@sideway/formula" "^3.0.1"
+    "@sideway/pinpoint" "^2.0.0"
+
 joi@^17.7.0:
   version "17.8.4"
   resolved "https://registry.yarnpkg.com/joi/-/joi-17.8.4.tgz#f2d91ab8acd3cca4079ba70669c65891739234aa"
@@ -13710,6 +13713,13 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+locate-path@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-7.2.0.tgz#69cb1779bd90b35ab1e771e1f2f89a202c2a8a8a"
+  integrity sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==
+  dependencies:
+    p-locate "^6.0.0"
 
 lock@^1.1.0:
   version "1.1.0"
@@ -15740,6 +15750,13 @@ p-limit@^2.0.0, p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-4.0.0.tgz#914af6544ed32bfa54670b061cafcbd04984b644"
+  integrity sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==
+  dependencies:
+    yocto-queue "^1.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -15767,6 +15784,13 @@ p-locate@^5.0.0:
   integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
   dependencies:
     p-limit "^3.0.2"
+
+p-locate@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-6.0.0.tgz#3da9a49d4934b901089dca3302fa65dc5a05c04f"
+  integrity sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==
+  dependencies:
+    p-limit "^4.0.0"
 
 p-map-series@^2.1.0:
   version "2.1.0"
@@ -15965,7 +15989,7 @@ parse-json@^4.0.0:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
 
-parse-json@^5.0.0:
+parse-json@^5.0.0, parse-json@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
   integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
@@ -16089,6 +16113,11 @@ path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
+
+path-exists@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-5.0.0.tgz#a6aad9489200b21fab31e49cf09277e5116fb9e7"
+  integrity sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
@@ -17459,6 +17488,15 @@ read-pkg-up@^7.0.1:
     read-pkg "^5.2.0"
     type-fest "^0.8.1"
 
+read-pkg-up@^9.0.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-9.1.0.tgz#38ca48e0bc6c6b260464b14aad9bcd4e5b1fbdc3"
+  integrity sha512-vaMRR1AC1nrd5CQM0PhlRsO5oc2AAigqr7cCrZ/MW/Rsaflz4RlgzkpL4qoU/z1F6wrbd85iFv1OQj/y5RdGvg==
+  dependencies:
+    find-up "^6.3.0"
+    read-pkg "^7.1.0"
+    type-fest "^2.5.0"
+
 read-pkg@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
@@ -17486,6 +17524,16 @@ read-pkg@^5.2.0:
     normalize-package-data "^2.5.0"
     parse-json "^5.0.0"
     type-fest "^0.6.0"
+
+read-pkg@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-7.1.0.tgz#438b4caed1ad656ba359b3e00fd094f3c427a43e"
+  integrity sha512-5iOehe+WF75IccPc30bWTbpdDQLOCc3Uu8bi3Dte3Eueij81yx1Mrufk8qBx/YAbR4uL1FdUr+7BKXDwEtisXg==
+  dependencies:
+    "@types/normalize-package-data" "^2.4.1"
+    normalize-package-data "^3.0.2"
+    parse-json "^5.2.0"
+    type-fest "^2.0.0"
 
 read@1, read@^1.0.7, read@~1.0.1:
   version "1.0.7"
@@ -20035,7 +20083,7 @@ type-fest@^1.2.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
   integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
 
-type-fest@^2.1.0:
+type-fest@^2.0.0, type-fest@^2.1.0, type-fest@^2.5.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
   integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
@@ -20093,6 +20141,11 @@ ua-parser-js@^0.7.30:
   version "0.7.31"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.31.tgz#649a656b191dffab4f21d5e053e27ca17cbff5c6"
   integrity sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==
+
+ufo@^0.7.10:
+  version "0.7.11"
+  resolved "https://registry.yarnpkg.com/ufo/-/ufo-0.7.11.tgz#17defad497981290383c5d26357773431fdbadcb"
+  integrity sha512-IT3q0lPvtkqQ8toHQN/BkOi4VIqoqheqM1FnkNWT9y0G8B3xJhwnoKBu5OHx8zHDOvveQzfKuFowJ0VSARiIDg==
 
 uglify-js@^3.1.4:
   version "3.17.0"
@@ -21307,6 +21360,11 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+yocto-queue@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
+  integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
 
 yoga-layout-prebuilt@^1.10.0:
   version "1.10.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Package

<!--- Which packages are affected? Put an `x` in all the boxes that apply: -->

- [x] gatsby-source-prismic
- [x] gatsby-plugin-prismic-previews

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR updates `@imgix/gatsby` to the latest version. Updating the package fixes a bug preventing Gatsby >= v5.10.0 projects from starting or building.

See #531 for more details.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [ ] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
