### PR TITLE
fix(previews): correctly resolve the `url` property in link fields

### DIFF
--- a/packages/gatsby-plugin-prismic-previews/src/lib/normalizeDocument.ts
+++ b/packages/gatsby-plugin-prismic-previews/src/lib/normalizeDocument.ts
@@ -58,8 +58,6 @@ const withDocumentProxy = <
 			if (prop === "document") {
 				if (hasOwnProperty(target, "id") && typeof target.id === "string") {
 					return getDocument(target.id) || null;
-				} else {
-					return null;
 				}
 			} else if (prop === "url") {
 				if (hasOwnProperty(target, "id") && typeof target.id === "string") {
@@ -70,12 +68,10 @@ const withDocumentProxy = <
 							linkResolver: repositoryConfig.linkResolver,
 						});
 					}
-				} else {
-					return null;
 				}
-			} else {
-				return Reflect.get(target, prop, receiver);
 			}
+
+			return Reflect.get(target, prop, receiver);
 		},
 	});
 };
@@ -238,8 +234,8 @@ const normalizeField = async (
 										variationModel.primary || {},
 										[...path, slice.slice_type, "primary"],
 										sharedSliceModels,
-										pluginOptions,
 										repositoryConfig,
+										pluginOptions,
 									);
 
 									result.items = await Promise.all(
@@ -249,8 +245,8 @@ const normalizeField = async (
 												variationModel.items || {},
 												[...path, slice.slice_type, "item"],
 												sharedSliceModels,
-												pluginOptions,
 												repositoryConfig,
+												pluginOptions,
 											);
 										}),
 									);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a bug during previews where the `url` property in link fields always returned `null`.

This happened because link fields are wrapped with `withDocumentProxy()`, which intercepts the `document` and `url` properties to return the correct values in content relationship fields. `withDocumentProxy()` was incorrectly returning `null` for all fields that are not content relationships.

**Note**: Using `Proxy` is necessary to support content relationships and the `document` property. In Gatsby's GraphQL API, `document` refers to the linked document, which has full access to the document's data. If you `console.log()` a link or content relationship field, you will see a `Proxy` object, not a standard object. **This is normal**.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
