### PR TITLE
docs(#544): update links from old to new repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -441,5 +441,5 @@ The minimum Node version supported by the project is stated under the `engines` 
 [template-issue]: https://github.com/prismicio/prismic-typescript-template/issues/new/choose
 [changelog]: ./CHANGELOG.md
 [forum-question]: https://community.prismic.io
-[repo-issue]: https://github.com/prismicio-community/prismic-gatsby-early-access/issues/new/choose
-[repo-pull-requests]: https://github.com/prismicio-community/prismic-gatsby-early-access/pulls
+[repo-issue]: https://github.com/prismicio/prismic-gatsby/issues/new/choose
+[repo-pull-requests]: https://github.com/prismicio/prismic-gatsby/pulls

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ For more clarity on this project and its structure you can also check out the de
 
 ### A note on how this repository is organized
 
-This repository is a monorepo managed using [npm workspaces](https://docs.npmjs.com/cli/v7/using-npm/workspaces). This means there are [multiple packages](https://github.com/prismicio-community/prismic-gatsby-early-access/tree/main/packages) managed in this codebase, even though we publish them to [npm](https://www.npmjs.com/) as separate packages.
+This repository is a monorepo managed using [npm workspaces](https://docs.npmjs.com/cli/v7/using-npm/workspaces). This means there are [multiple packages](https://github.com/prismicio/prismic-gatsby/tree/main/packages) managed in this codebase, even though we publish them to [npm](https://www.npmjs.com/) as separate packages.
 
 ## License
 
@@ -72,6 +72,6 @@ limitations under the License.
 <!-- TODO: Replace link with a more useful one if available -->
 
 [forum-question]: https://community.prismic.io
-[repo-bug-report]: https://github.com/prismicio-community/prismic-gatsby-early-access/issues/new?assignees=&labels=bug&template=bug_report.md&title=
-[repo-feature-request]: https://github.com/prismicio-community/prismic-gatsby-early-access/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=
-[repo-pull-requests]: https://github.com/prismicio-community/prismic-gatsby-early-access/pulls
+[repo-bug-report]: https://github.com/prismicio/prismic-gatsby/issues/new?assignees=&labels=bug&template=bug_report.md&title=
+[repo-feature-request]: https://github.com/prismicio/prismic-gatsby/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=
+[repo-pull-requests]: https://github.com/prismicio/prismic-gatsby/pulls

--- a/packages/gatsby-plugin-prismic-previews/CHANGELOG.md
+++ b/packages/gatsby-plugin-prismic-previews/CHANGELOG.md
@@ -3,18 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [6.0.1](https://github.com/prismicio-community/prismic-gatsby-early-access/compare/v6.0.0...v6.0.1) (2023-09-05)
+## [6.0.1](https://github.com/prismicio/prismic-gatsby/compare/v6.0.0...v6.0.1) (2023-09-05)
 
 
 ### Bug Fixes
 
-* **previews:** correctly resolve the `url` property in link fields ([#542](https://github.com/prismicio-community/prismic-gatsby-early-access/issues/542)) ([0a426c5](https://github.com/prismicio-community/prismic-gatsby-early-access/commit/0a426c5f64b74af36f8b1c656355d44502c2ecfd))
+* **previews:** correctly resolve the `url` property in link fields ([#542](https://github.com/prismicio/prismic-gatsby/issues/542)) ([0a426c5](https://github.com/prismicio/prismic-gatsby/commit/0a426c5f64b74af36f8b1c656355d44502c2ecfd))
 
 
 
 
 
-# [6.0.0](https://github.com/prismicio-community/prismic-gatsby-early-access/compare/v5.3.1...v6.0.0) (2023-06-29)
+# [6.0.0](https://github.com/prismicio/prismic-gatsby/compare/v5.3.1...v6.0.0) (2023-06-29)
 
 **Note:** Version bump only for package gatsby-plugin-prismic-previews
 

--- a/packages/gatsby-plugin-prismic-previews/README.md
+++ b/packages/gatsby-plugin-prismic-previews/README.md
@@ -61,22 +61,22 @@ limitations under the License.
 [prismic]: https://prismic.io
 [gatsby]: https://www.gatsbyjs.com/
 [prismic-previews]: https://prismic.io/docs/core-concepts/preview-setup
-[gatsby-source-prismic]: https://github.com/prismicio-community/prismic-gatsby-early-access/tree/main/packages/gatsby-source-prismic
+[gatsby-source-prismic]: https://github.com/prismicio/prismic-gatsby/tree/main/packages/gatsby-source-prismic
 [prismic-toolbar]: https://prismic.io/docs/technologies/previews-and-the-prismic-toolbar-javascript
 [gatsby-cloud]: https://www.gatsbyjs.com/products/cloud/
 
 <!-- TODO: Replace link with a more useful one if available -->
 
 [prismic-docs]: https://prismic.io/docs/technologies/gatsby
-[changelog]: https://github.com/prismicio-community/prismic-gatsby-early-access/blob/main/packages/gatsby-plugin-prismic-previews/CHANGELOG.md
-[contributing]: https://github.com/prismicio-community/prismic-gatsby-early-access/blob/main/CONTRIBUTING.md
+[changelog]: https://github.com/prismicio/prismic-gatsby/blob/main/packages/gatsby-plugin-prismic-previews/CHANGELOG.md
+[contributing]: https://github.com/prismicio/prismic-gatsby/blob/main/CONTRIBUTING.md
 
 <!-- TODO: Replace link with a more useful one if available -->
 
 [forum-question]: https://community.prismic.io
-[repo-bug-report]: https://github.com/prismicio-community/prismic-gatsby-early-access/issues/new?assignees=&labels=bug&template=bug_report.md&title=
-[repo-feature-request]: https://github.com/prismicio-community/prismic-gatsby-early-access/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=
-[repo-pull-requests]: https://github.com/prismicio-community/prismic-gatsby-early-access/pulls
+[repo-bug-report]: https://github.com/prismicio/prismic-gatsby/issues/new?assignees=&labels=bug&template=bug_report.md&title=
+[repo-feature-request]: https://github.com/prismicio/prismic-gatsby/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=
+[repo-pull-requests]: https://github.com/prismicio/prismic-gatsby/pulls
 
 <!-- Badges -->
 
@@ -84,10 +84,10 @@ limitations under the License.
 [npm-version-href]: https://npmjs.com/package/gatsby-plugin-prismic-previews
 [npm-downloads-src]: https://img.shields.io/npm/dm/gatsby-plugin-prismic-previews.svg
 [npm-downloads-href]: https://npmjs.com/package/gatsby-plugin-prismic-previews
-[github-actions-ci-src]: https://github.com/prismicio-community/prismic-gatsby-early-access/workflows/ci/badge.svg
-[github-actions-ci-href]: https://github.com/prismicio-community/prismic-gatsby-early-access/actions?query=workflow%3Aci
-[codecov-src]: https://img.shields.io/codecov/c/github/prismicio-community/prismic-gatsby-early-access.svg
-[codecov-href]: https://codecov.io/gh/prismicio-community/prismic-gatsby-early-access
+[github-actions-ci-src]: https://github.com/prismicio/prismic-gatsby/workflows/ci/badge.svg
+[github-actions-ci-href]: https://github.com/prismicio/prismic-gatsby/actions?query=workflow%3Aci
+[codecov-src]: https://img.shields.io/codecov/c/github/prismicio/prismic-gatsby.svg
+[codecov-href]: https://codecov.io/gh/prismicio/prismic-gatsby
 [conventional-commits-src]: https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg
 [conventional-commits-href]: https://conventionalcommits.org
 [license-src]: https://img.shields.io/npm/l/gatsby-plugin-prismic-previews.svg

--- a/packages/gatsby-plugin-prismic-previews/package.json
+++ b/packages/gatsby-plugin-prismic-previews/package.json
@@ -10,8 +10,9 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "ssh://git@github.com/prismicio-community/prismic-gatsby-early-access.git"
+		"url": "git+https://github.com/prismicio/prismic-gatsby.git"
 	},
+	"homepage": "https://github.com/prismicio/prismic-gatsby/tree/main/packages/gatsby-plugin-prismic-previews",
 	"license": "Apache-2.0",
 	"author": "Prismic <contact@prismic.io> (https://prismic.io)",
 	"sideEffects": false,

--- a/packages/gatsby-source-prismic/CHANGELOG.md
+++ b/packages/gatsby-source-prismic/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [6.0.1](https://github.com/prismicio-community/prismic-gatsby-early-access/compare/v6.0.0...v6.0.1) (2023-09-05)
+## [6.0.1](https://github.com/prismicio/prismic-gatsby/compare/v6.0.0...v6.0.1) (2023-09-05)
 
 **Note:** Version bump only for package gatsby-source-prismic
 
@@ -11,7 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [6.0.0](https://github.com/prismicio-community/prismic-gatsby-early-access/compare/v5.3.1...v6.0.0) (2023-06-29)
+# [6.0.0](https://github.com/prismicio/prismic-gatsby/compare/v5.3.1...v6.0.0) (2023-06-29)
 
 **Note:** Version bump only for package gatsby-source-prismic
 

--- a/packages/gatsby-source-prismic/README.md
+++ b/packages/gatsby-source-prismic/README.md
@@ -61,7 +61,7 @@ limitations under the License.
 [gatsby]: https://www.gatsbyjs.com/
 [prismic-slices]: https://prismic.io/docs/core-concepts/slices
 [gatsby-plugin-image]: https://www.gatsbyjs.com/plugins/gatsby-plugin-image/
-[gatsby-plugin-prismic-previews]: https://github.com/prismicio-community/prismic-gatsby-early-access/tree/main/packages/gatsby-plugin-prismic-previews
+[gatsby-plugin-prismic-previews]: https://github.com/prismicio/prismic-gatsby/tree/main/packages/gatsby-plugin-prismic-previews
 [gatsby-transformer-sharp]: https://www.gatsbyjs.com/plugins/gatsby-transformer-sharp/
 [imgix]: https://imgix.com/
 [prismic-previews]: https://prismic.io/docs/core-concepts/preview-setup
@@ -72,15 +72,15 @@ limitations under the License.
 <!-- TODO: Replace link with a more useful one if available -->
 
 [prismic-docs]: https://prismic.io/docs/technologies/gatsby
-[changelog]: https://github.com/prismicio-community/prismic-gatsby-early-access/blob/main/packages/gatsby-source-prismic/CHANGELOG.md
-[contributing]: https://github.com/prismicio-community/prismic-gatsby-early-access/blob/main/CONTRIBUTING.md
+[changelog]: https://github.com/prismicio/prismic-gatsby/blob/main/packages/gatsby-source-prismic/CHANGELOG.md
+[contributing]: https://github.com/prismicio/prismic-gatsby/blob/main/CONTRIBUTING.md
 
 <!-- TODO: Replace link with a more useful one if available -->
 
 [forum-question]: https://community.prismic.io
-[repo-bug-report]: https://github.com/prismicio-community/prismic-gatsby-early-access/issues/new?assignees=&labels=bug&template=bug_report.md&title=
-[repo-feature-request]: https://github.com/prismicio-community/prismic-gatsby-early-access/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=
-[repo-pull-requests]: https://github.com/prismicio-community/prismic-gatsby-early-access/pulls
+[repo-bug-report]: https://github.com/prismicio/prismic-gatsby/issues/new?assignees=&labels=bug&template=bug_report.md&title=
+[repo-feature-request]: https://github.com/prismicio/prismic-gatsby/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=
+[repo-pull-requests]: https://github.com/prismicio/prismic-gatsby/pulls
 
 <!-- Badges -->
 
@@ -88,10 +88,10 @@ limitations under the License.
 [npm-version-href]: https://npmjs.com/package/gatsby-source-prismic
 [npm-downloads-src]: https://img.shields.io/npm/dm/gatsby-source-prismic.svg
 [npm-downloads-href]: https://npmjs.com/package/gatsby-source-prismic
-[github-actions-ci-src]: https://github.com/prismicio-community/prismic-gatsby-early-access/workflows/ci/badge.svg
-[github-actions-ci-href]: https://github.com/prismicio-community/prismic-gatsby-early-access/actions?query=workflow%3Aci
-[codecov-src]: https://img.shields.io/codecov/c/github/prismicio-community/prismic-gatsby-early-access.svg
-[codecov-href]: https://codecov.io/gh/prismicio-community/prismic-gatsby-early-access
+[github-actions-ci-src]: https://github.com/prismicio/prismic-gatsby/workflows/ci/badge.svg
+[github-actions-ci-href]: https://github.com/prismicio/prismic-gatsby/actions?query=workflow%3Aci
+[codecov-src]: https://img.shields.io/codecov/c/github/prismicio/prismic-gatsby.svg
+[codecov-href]: https://codecov.io/gh/prismicio/prismic-gatsby
 [conventional-commits-src]: https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg
 [conventional-commits-href]: https://conventionalcommits.org
 [license-src]: https://img.shields.io/npm/l/gatsby-source-prismic.svg

--- a/packages/gatsby-source-prismic/package.json
+++ b/packages/gatsby-source-prismic/package.json
@@ -10,8 +10,9 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "ssh://git@github.com/prismicio-community/prismic-gatsby-early-access.git"
+		"url": "git+https://github.com/prismicio/prismic-gatsby.git"
 	},
+	"homepage": "https://github.com/prismicio/prismic-gatsby/tree/main/packages/gatsby-source-prismic",
 	"license": "Apache-2.0",
 	"author": "Prismic <contact@prismic.io> (https://prismic.io)",
 	"sideEffects": false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

Fix broken links in markdown and package.json files by updating the repository.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

- Fixes #544 
- Update links from old `prismicio-community/prismic-gatsby-early-access` to new `prismicio/prismic-gatsby` repository
- Add `homepage` in package.json of `gatsby-source-prismic` and `gatsby-plugin-prismic-previews` to directly link to the package
- Fix some but not all links in CHANGELOG.md since previous tags are not available anymore and commits are not the same anymore

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [ ] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
🦦