### PR TITLE
fix type error on `link.raw`

### DIFF
--- a/packages/gatsby-source-prismic/src/gatsby-node/createSchemaCustomization.ts
+++ b/packages/gatsby-source-prismic/src/gatsby-node/createSchemaCustomization.ts
@@ -317,6 +317,9 @@ export const createSchemaCustomization = async <
 					type: "JSON!",
 					description:
 						"**Do not use this field unless you know what you are doing**. The unprocessed field value returned from the Prismic REST API.",
+					resolve: (source: object): object => {
+						return source;
+					},
 				},
 			},
 		}),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

There is type error on `PrismicLinkType` so build fails when using `raw` field.

```
The field "PrismicLinkField.raw." was explicitly defined as non-nullable via the schema customization API (by yourself or a plugin/theme). This means that this field is not optional and you have to define a value. If this is not your desired behavior and you defined the schema yourself, go to "createTypes" in gatsby-node.
```

This causes because there is no `raw` field in actual data. It should be virtually provided for field data.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [ ] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [ ] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
