### PR TITLE
fix: return all repeated items of a SharedSlice, not just the first item

### DIFF
--- a/packages/gatsby-source-prismic/src/lib/normalizeDocument.ts
+++ b/packages/gatsby-source-prismic/src/lib/normalizeDocument.ts
@@ -80,7 +80,7 @@ const normalizeDocumentField = async <
 									});
 
 								if (sharedSliceModel && sharedSliceVariationModel) {
-									const [primary, items] = await Promise.all([
+									const [primary, ...items] = await Promise.all([
 										normalizeDocumentFieldRecord({
 											...args,
 											models: sharedSliceVariationModel.primary || {},


### PR DESCRIPTION
## Types of changes

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Current shared slices with repeated items will only return the first item. This causes GraphQL to error as it expects an Iterable but the data is returning an object.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [ ] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [ ] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
